### PR TITLE
added energy.batteries to drivers.thermostat

### DIFF
--- a/app.json
+++ b/app.json
@@ -203,7 +203,12 @@
           "id": "add_devices",
           "template": "add_devices"
         }
-      ]
+      ],
+      "energy":
+      {
+        "batteries":
+          ["AA", "AA"]
+      }
     },
     {
       "id": "socket",


### PR DESCRIPTION
When building got an error:
> Warning: drivers.thermostat is missing an array 'energy.batteries' because the capability measure_battery is being used. Specifying the type of battery will be required in the future.

According to the docs the thermostats (DECT-300 & DECT-301 are the only ones?) use 2xAA's.